### PR TITLE
fix: enhance setup-git.sh to add error handling and env checks.

### DIFF
--- a/.devcontainer/setup-git.sh
+++ b/.devcontainer/setup-git.sh
@@ -1,18 +1,31 @@
 #!/bin/bash
 
-git config --global --add safe.directory "${HOME}/workspace"
+# Check if required environment variables are set
+if [ -z "$GIT_USER" ] || [ -z "$GIT_EMAIL" ]; then
+    echo "GIT_USER or GIT_EMAIL is not set."
+    exit 1
+fi
 
-git config --global init.defaultBranch main
+# Store the workspace path in a variable
+WORKSPACE_DIR="${HOME}/workspace"
 
-git config --global user.name "${GIT_USER}"
+# Apply Git configurations
+echo "Setting up git configurations..."
 
-git config --global user.email "${GIT_EMAIL}"
+git config --global --add safe.directory "${WORKSPACE_DIR}" || { echo "Failed to add safe directory"; exit 1; }
+git config --global init.defaultBranch main || { echo "Failed to set default branch"; exit 1; }
+git config --global user.name "${GIT_USER}" || { echo "Failed to set user name"; exit 1; }
+git config --global user.email "${GIT_EMAIL}" || { echo "Failed to set user email"; exit 1; }
+git config --global core.editor "code --wait" || { echo "Failed to set core editor"; exit 1; }
 
-git config --global core.editor "code --wait"
+# Change to the workspace directory
+cd "${WORKSPACE_DIR}" || { echo "Failed to change directory to ${WORKSPACE_DIR}"; exit 1; }
 
-git config commit.template "${HOME}/workspace/commitTemplate.txt"
+# Set commit template and hooks path
+git config commit.template "${WORKSPACE_DIR}/commitTemplate.txt" || { echo "Failed to set commit template"; exit 1; }
+git config core.hooksPath "${WORKSPACE_DIR}/.githooks" || { echo "Failed to set hooks path"; exit 1; }
 
-git config core.hooksPath "${HOME}/workspace/.githooks"
+# Make the pre-commit hook executable
+chmod +x "${WORKSPACE_DIR}/.githooks/pre-commit" || { echo "Failed to make pre-commit hook executable"; exit 1; }
 
-chmod +x ../.githooks/pre-commit
-
+echo "Git configuration completed successfully."


### PR DESCRIPTION
## Description

This PR enhances the `setup-git.sh` script by adding error handling and checks for required environment variables. It ensures that the script exits gracefully if `GIT_USER` or `GIT_EMAIL` are not set, and it includes error messages for failed Git configuration commands.

## Changes
- Added checks for `GIT_USER` and `GIT_EMAIL` environment variables.
- Introduced error handling for each Git configuration command.
- Changed to the workspace directory before applying specific configurations.
- Improved script messages for better clarity during execution.
- Add `cd ~/workspace`
