### PR TITLE
Feature/add token introspection

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,42 @@
+# devcontainer
+
+## workspace
+- package
+    - vim
+    - curl
+    - unzip
+    - zip
+    - tzdata
+    - git
+    - atc..
+- sdkman
+    - java
+    - gradle
+    - maven
+    - kotlin
+- nvm
+- z
+
+## postgres
+
+## nginx
+
+## keycloak
+
+## docker compose diagram
+```mermaid
+graph LR
+    subgraph docker-network
+        subgraph workspace[workspace:9999]
+            java
+            gradle
+            kotlin
+            atc...
+        end
+        postgres[postgres:5432]
+        keycloak[keycloak:8080]
+    end
+
+    workspace --> postgres
+    workspace --> keycloak
+```

--- a/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/configs/ClientAppConfiguration.kt
+++ b/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/configs/ClientAppConfiguration.kt
@@ -1,0 +1,16 @@
+package com.minmin.authHandsOnClient.configs
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "clientapp.config")
+class ClientAppConfiguration {
+    lateinit var apiserverUrl: String
+    lateinit var authorizationEndpoint: String
+    lateinit var tokenEndpoint: String
+    lateinit var revokeEndpoint: String
+    lateinit var clientId: String
+    lateinit var clientSecret: String
+    lateinit var scope: String
+}

--- a/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/configs/OauthConfiguration.kt
+++ b/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/configs/OauthConfiguration.kt
@@ -1,0 +1,13 @@
+package com.minmin.authHandsOnClient.configs
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "oauth.config")
+class OauthConfiguration {
+    var state: Boolean = false
+    var nonce: Boolean = false
+    var pkce: Boolean = false
+    var formPost: Boolean = false
+}

--- a/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/controllers/TokenIntrospectionController.kt
+++ b/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/controllers/TokenIntrospectionController.kt
@@ -1,31 +1,26 @@
 package com.minmin.authHandsOnClient.controllers
 
 import com.minmin.authHandsOnClient.configs.ClientAppConfiguration
+import com.minmin.authHandsOnClient.configs.OauthConfiguration
 import com.minmin.authHandsOnClient.dtos.ClientSession
-import com.minmin.authHandsOnClient.dtos.TokenResponse
 import com.minmin.authHandsOnClient.services.TokenIntrospectionService
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
-import org.springframework.http.MediaType
 import org.springframework.http.RequestEntity
-import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
-import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.client.HttpStatusCodeException
-import org.springframework.web.client.ResourceAccessException
 import org.springframework.web.client.RestTemplate
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 import java.net.URI
 
 @Controller
 class TokenIntrospectionController(
     val clientSession: ClientSession,
     val clientConfig: ClientAppConfiguration,
+    val oauthConfig: OauthConfiguration,
     val tokenIntrospectionService: TokenIntrospectionService,
 ) {
     @RequestMapping("/")
@@ -38,7 +33,6 @@ class TokenIntrospectionController(
         @RequestParam(name = "scope", required = false) scope: String?,
     ): String {
         clientSession.scope = scope
-
         val authUrl = tokenIntrospectionService.buildAuthorizationUrl(scope)
 
         return String.format("redirect:%s", authUrl)
@@ -46,56 +40,28 @@ class TokenIntrospectionController(
 
     @GetMapping("/gettoken")
     fun getToken(
-        @RequestParam(name = "code", required = false) code: String?,
+        @RequestParam(name = "code", required = false) code: String,
         @RequestParam(name = "state", required = false) state: String?,
         @RequestParam(name = "error", required = false) error: String?,
         @RequestParam(name = "error_description", required = false) errorDescription: String?,
         model: Model,
     ): String {
+        if (oauthConfig.formPost) {
+            return "gettoken"
+        }
+
         error?.let {
             model.addAttribute("error", error)
             model.addAttribute("errorDescription", errorDescription)
             return "gettoken"
         }
 
-        val headers = HttpHeaders()
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED)
-        headers.setBasicAuth(clientConfig.clientId, clientConfig.clientSecret)
-
-        var redirectUrl =
-            ServletUriComponentsBuilder.fromCurrentRequest()
-                .replacePath("/gettoken")
-                .replaceQuery(null)
-                .toUriString()
-        val params = LinkedMultiValueMap<String, String>()
-        params.add("code", code)
-        params.add("grant_type", "authorization_code")
-        params.add("redirect_uri", redirectUrl)
-
-        val req =
-            RequestEntity<Any>(
-                params,
-                headers,
-                HttpMethod.POST,
-                URI.create(
-                    clientConfig.tokenEndpoint,
-                ),
-            )
-        var token: TokenResponse? = null
-
-        try {
-            val res: ResponseEntity<TokenResponse> =
-                RestTemplate().exchange(req, TokenResponse::class.java)
-            token = res.body
-        } catch (e: HttpStatusCodeException) {
-            TokenResponse.withError(e.message, e.getResponseBodyAsString())
-        } catch (e: ResourceAccessException) {
-            TokenResponse.withError(e.message, null)
-        }
+        val token = tokenIntrospectionService.processAuthorizationCodeGrant(code, state)
 
         if (token?.error != null) {
             model.addAttribute("error", token.error)
             model.addAttribute("errorDescription", token.errorDescription)
+            return "gettoken"
         }
 
         clientSession.setTokensFromTokenResponse(token)

--- a/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/dtos/IdToken.kt
+++ b/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/dtos/IdToken.kt
@@ -4,4 +4,4 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
-class IdToken(val scope: String) : JsonWebToken()
+class IdToken(val nonce: String?) : JsonWebToken()

--- a/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/services/TokenIntrospectionService.kt
+++ b/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/services/TokenIntrospectionService.kt
@@ -1,0 +1,73 @@
+package com.minmin.authHandsOnClient.services
+
+import com.minmin.authHandsOnClient.configs.ClientAppConfiguration
+import com.minmin.authHandsOnClient.configs.OauthConfiguration
+import com.minmin.authHandsOnClient.dtos.ClientSession
+import com.minmin.authHandsOnClient.utils.OauthUtil
+import org.springframework.stereotype.Service
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URLEncoder
+import java.nio.charset.Charset
+import java.util.UUID
+
+@Service
+class TokenIntrospectionService(
+    val clientSession: ClientSession,
+    val clientConfig: ClientAppConfiguration,
+    val oauthConfig: OauthConfiguration,
+) {
+    private val charset = Charset.defaultCharset().toString()
+
+    fun buildAuthorizationUrl(scope: String?): String {
+        val authorizationUrl =
+            UriComponentsBuilder.fromUriString(clientConfig.authorizationEndpoint)
+        val params = buildAuthrizationParams(scope)
+
+        return authorizationUrl.queryParams(params).build(true).toUriString()
+    }
+
+    private fun buildAuthrizationParams(scope: String?): LinkedMultiValueMap<String, String> {
+        val params = LinkedMultiValueMap<String, String>()
+        val recirectUri = buildRedirectUri("/gettoken")
+
+        params.add("redirect_uri", recirectUri)
+        params.add("response_type", "code")
+        params.add("client_id", clientConfig.clientId)
+        scope?.takeIf { it.isNotEmpty() }?.let {
+            params.add("scope", URLEncoder.encode(it, charset))
+        }
+
+        if (oauthConfig.state) {
+            val state = UUID.randomUUID().toString()
+            clientSession.state = state
+            params.add("state", state)
+        }
+        if (oauthConfig.nonce) {
+            val nonce = UUID.randomUUID().toString()
+            clientSession.nonce = nonce
+            params.add("nonce", nonce)
+        }
+        if (oauthConfig.pkce) {
+            val codeVerifier = OauthUtil.generateCodeVerifier()
+            val codeChallenge = OauthUtil.generateCodeChallenge(codeVerifier)
+            clientSession.codeVerifier = codeVerifier
+            params.add("code_challenge_method", "S256")
+            params.add("code_challenge", codeChallenge)
+        }
+        if (oauthConfig.formPost) {
+            params.add("response_mode", "form_post")
+        }
+
+        return params
+    }
+
+    private fun buildRedirectUri(replacePath: String): String {
+        return ServletUriComponentsBuilder.fromCurrentRequest()
+            .replacePath(replacePath)
+            .replaceQuery(null)
+            .toUriString()
+            .let { URLEncoder.encode(it, charset) }
+    }
+}

--- a/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/services/TokenIntrospectionService.kt
+++ b/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/services/TokenIntrospectionService.kt
@@ -7,10 +7,6 @@ import com.minmin.authHandsOnClient.dtos.IdToken
 import com.minmin.authHandsOnClient.dtos.JsonWebToken
 import com.minmin.authHandsOnClient.dtos.TokenResponse
 import com.minmin.authHandsOnClient.utils.OauthUtil
-import java.net.URI
-import java.net.URLEncoder
-import java.nio.charset.Charset
-import java.util.UUID
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
@@ -23,26 +19,30 @@ import org.springframework.web.client.ResourceAccessException
 import org.springframework.web.client.RestTemplate
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 import org.springframework.web.util.UriComponentsBuilder
+import java.net.URI
+import java.net.URLEncoder
+import java.nio.charset.Charset
+import java.util.UUID
 
 @Service
 class TokenIntrospectionService(
-        val clientSession: ClientSession,
-        val clientConfig: ClientAppConfiguration,
-        val oauthConfig: OauthConfiguration,
+    val clientSession: ClientSession,
+    val clientConfig: ClientAppConfiguration,
+    val oauthConfig: OauthConfiguration,
 ) {
     private val charset = Charset.defaultCharset().toString()
 
     fun buildAuthorizationUrl(scope: String?): String {
         val authorizationUrl =
-                UriComponentsBuilder.fromUriString(clientConfig.authorizationEndpoint)
+            UriComponentsBuilder.fromUriString(clientConfig.authorizationEndpoint)
         val params = buildAuthrizationParams(scope)
 
         return authorizationUrl.queryParams(params).build(true).toUriString()
     }
 
     fun processAuthorizationCodeGrant(
-            code: String,
-            state: String?,
+        code: String,
+        state: String?,
     ): TokenResponse? {
         if (oauthConfig.state) {
             state?.takeIf { !it.equals(clientSession.state) }?.let {
@@ -107,14 +107,14 @@ class TokenIntrospectionService(
     }
 
     private fun buildRedirectUri(
-            replacePath: String,
-            isEncode: Boolean = false,
+        replacePath: String,
+        isEncode: Boolean = false,
     ): String {
         return ServletUriComponentsBuilder.fromCurrentRequest()
-                .replacePath(replacePath)
-                .replaceQuery(null)
-                .toUriString()
-                .let { if (isEncode) URLEncoder.encode(it, charset) else it }
+            .replacePath(replacePath)
+            .replaceQuery(null)
+            .toUriString()
+            .let { if (isEncode) URLEncoder.encode(it, charset) else it }
     }
 
     private fun requestToken(authorizationCode: String): TokenResponse? {
@@ -133,18 +133,18 @@ class TokenIntrospectionService(
         }
 
         val req =
-                RequestEntity<Any>(
-                        params,
-                        headers,
-                        HttpMethod.POST,
-                        URI.create(
-                                clientConfig.tokenEndpoint,
-                        ),
-                )
+            RequestEntity<Any>(
+                params,
+                headers,
+                HttpMethod.POST,
+                URI.create(
+                    clientConfig.tokenEndpoint,
+                ),
+            )
 
         try {
             val res: ResponseEntity<TokenResponse> =
-                    RestTemplate().exchange(req, TokenResponse::class.java)
+                RestTemplate().exchange(req, TokenResponse::class.java)
             return res.body
         } catch (e: HttpStatusCodeException) {
             return TokenResponse.withError(e.message, e.getResponseBodyAsString())

--- a/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/services/TokenIntrospectionService.kt
+++ b/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/services/TokenIntrospectionService.kt
@@ -3,34 +3,77 @@ package com.minmin.authHandsOnClient.services
 import com.minmin.authHandsOnClient.configs.ClientAppConfiguration
 import com.minmin.authHandsOnClient.configs.OauthConfiguration
 import com.minmin.authHandsOnClient.dtos.ClientSession
+import com.minmin.authHandsOnClient.dtos.IdToken
+import com.minmin.authHandsOnClient.dtos.JsonWebToken
+import com.minmin.authHandsOnClient.dtos.TokenResponse
 import com.minmin.authHandsOnClient.utils.OauthUtil
-import org.springframework.stereotype.Service
-import org.springframework.util.LinkedMultiValueMap
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder
-import org.springframework.web.util.UriComponentsBuilder
+import java.net.URI
 import java.net.URLEncoder
 import java.nio.charset.Charset
 import java.util.UUID
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.http.RequestEntity
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.client.HttpStatusCodeException
+import org.springframework.web.client.ResourceAccessException
+import org.springframework.web.client.RestTemplate
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder
+import org.springframework.web.util.UriComponentsBuilder
 
 @Service
 class TokenIntrospectionService(
-    val clientSession: ClientSession,
-    val clientConfig: ClientAppConfiguration,
-    val oauthConfig: OauthConfiguration,
+        val clientSession: ClientSession,
+        val clientConfig: ClientAppConfiguration,
+        val oauthConfig: OauthConfiguration,
 ) {
     private val charset = Charset.defaultCharset().toString()
 
     fun buildAuthorizationUrl(scope: String?): String {
         val authorizationUrl =
-            UriComponentsBuilder.fromUriString(clientConfig.authorizationEndpoint)
+                UriComponentsBuilder.fromUriString(clientConfig.authorizationEndpoint)
         val params = buildAuthrizationParams(scope)
 
         return authorizationUrl.queryParams(params).build(true).toUriString()
     }
 
+    fun processAuthorizationCodeGrant(
+            code: String,
+            state: String?,
+    ): TokenResponse? {
+        if (oauthConfig.state) {
+            state?.takeIf { !it.equals(clientSession.state) }?.let {
+                return TokenResponse.withError("state check NG.", null)
+            }
+        } else {
+            clientSession.state = null
+        }
+
+        val token = requestToken(code)
+
+        if (token?.error != null) {
+            return token
+        }
+
+        if (oauthConfig.nonce) {
+            val idToken = token?.idToken?.let { JsonWebToken.parse(it, IdToken::class) }
+
+            if (idToken?.nonce == null || !idToken.nonce.equals(clientSession.nonce)) {
+                return TokenResponse.withError("nonce check NG", null)
+            } else {
+                clientSession.nonce = null
+            }
+        }
+
+        return token
+    }
+
     private fun buildAuthrizationParams(scope: String?): LinkedMultiValueMap<String, String> {
         val params = LinkedMultiValueMap<String, String>()
-        val recirectUri = buildRedirectUri("/gettoken")
+        val recirectUri = buildRedirectUri("/gettoken", true)
 
         params.add("redirect_uri", recirectUri)
         params.add("response_type", "code")
@@ -63,11 +106,50 @@ class TokenIntrospectionService(
         return params
     }
 
-    private fun buildRedirectUri(replacePath: String): String {
+    private fun buildRedirectUri(
+            replacePath: String,
+            isEncode: Boolean = false,
+    ): String {
         return ServletUriComponentsBuilder.fromCurrentRequest()
-            .replacePath(replacePath)
-            .replaceQuery(null)
-            .toUriString()
-            .let { URLEncoder.encode(it, charset) }
+                .replacePath(replacePath)
+                .replaceQuery(null)
+                .toUriString()
+                .let { if (isEncode) URLEncoder.encode(it, charset) else it }
+    }
+
+    private fun requestToken(authorizationCode: String): TokenResponse? {
+        val headers = HttpHeaders()
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED)
+        headers.setBasicAuth(clientConfig.clientId, clientConfig.clientSecret)
+
+        var redirectUrl = buildRedirectUri("/gettoken")
+        val params = LinkedMultiValueMap<String, String>()
+        params.add("code", authorizationCode)
+        params.add("grant_type", "authorization_code")
+        params.add("redirect_uri", redirectUrl)
+
+        if (oauthConfig.pkce) {
+            params.add("code_verifier", clientSession.codeVerifier)
+        }
+
+        val req =
+                RequestEntity<Any>(
+                        params,
+                        headers,
+                        HttpMethod.POST,
+                        URI.create(
+                                clientConfig.tokenEndpoint,
+                        ),
+                )
+
+        try {
+            val res: ResponseEntity<TokenResponse> =
+                    RestTemplate().exchange(req, TokenResponse::class.java)
+            return res.body
+        } catch (e: HttpStatusCodeException) {
+            return TokenResponse.withError(e.message, e.getResponseBodyAsString())
+        } catch (e: ResourceAccessException) {
+            return TokenResponse.withError(e.message, null)
+        }
     }
 }

--- a/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/utils/Base64UrlUtil.kt
+++ b/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/utils/Base64UrlUtil.kt
@@ -2,23 +2,21 @@ package com.minmin.authHandsOnClient.utils
 
 import java.util.Base64
 
-class Base64UrlUtil {
-    companion object {
-        fun encode(octets: ByteArray): String {
-            var encoded = Base64.getEncoder().encodeToString(octets)
-            encoded = encoded.split("=")[0]
-            encoded = encoded.replace('+', '-')
-            encoded = encoded.replace('/', '_')
-            return encoded
-        }
+object Base64UrlUtil {
+    fun encode(octets: ByteArray): String {
+        var encoded = Base64.getEncoder().encodeToString(octets)
+        encoded = encoded.split("=")[0]
+        encoded = encoded.replace('+', '-')
+        encoded = encoded.replace('/', '_')
+        return encoded
+    }
 
-        fun decode(encodedContent: String): ByteArray {
-            var encodedContentVar = encodedContent.replace('-', '+').replace('_', '/')
-            when (encodedContentVar.length % 4) {
-                2 -> encodedContentVar += "=="
-                3 -> encodedContentVar += "="
-            }
-            return Base64.getDecoder().decode(encodedContentVar)
+    fun decode(encodedContent: String): ByteArray {
+        var encodedContentVar = encodedContent.replace('-', '+').replace('_', '/')
+        when (encodedContentVar.length % 4) {
+            2 -> encodedContentVar += "=="
+            3 -> encodedContentVar += "="
         }
+        return Base64.getDecoder().decode(encodedContentVar)
     }
 }

--- a/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/utils/JsonUtil.kt
+++ b/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/utils/JsonUtil.kt
@@ -6,43 +6,41 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import java.io.IOException
 
-class JsonUtil {
-    companion object {
-        private val mapper: ObjectMapper =
-            ObjectMapper().apply {
-                configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
-                configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
-                setSerializationInclusion(JsonInclude.Include.NON_NULL)
-            }
-
-        fun <T> unmarshal(
-            content: ByteArray,
-            type: Class<T>,
-        ): T {
-            return try {
-                mapper.readValue(content, type)
-            } catch (e: IOException) {
-                e.printStackTrace()
-                throw RuntimeException()
-            }
+object JsonUtil {
+    private val mapper: ObjectMapper =
+        ObjectMapper().apply {
+            configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+            configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
+            setSerializationInclusion(JsonInclude.Include.NON_NULL)
         }
 
-        fun marshal(obj: Any): String {
-            return marshal(obj, true)
+    fun <T> unmarshal(
+        content: ByteArray,
+        type: Class<T>,
+    ): T {
+        return try {
+            mapper.readValue(content, type)
+        } catch (e: IOException) {
+            e.printStackTrace()
+            throw RuntimeException()
         }
+    }
 
-        fun marshal(
-            obj: Any,
-            indent: Boolean,
-        ): String {
-            return try {
-                mapper.configure(SerializationFeature.INDENT_OUTPUT, indent)
-                mapper.writeValueAsString(obj)
-            } catch (e: IOException) {
-                e.printStackTrace()
-                ""
-            }
+    fun marshal(obj: Any): String {
+        return marshal(obj, true)
+    }
+
+    fun marshal(
+        obj: Any,
+        indent: Boolean,
+    ): String {
+        return try {
+            mapper.configure(SerializationFeature.INDENT_OUTPUT, indent)
+            mapper.writeValueAsString(obj)
+        } catch (e: IOException) {
+            e.printStackTrace()
+            ""
         }
     }
 }

--- a/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/utils/OauthUtil.kt
+++ b/auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/utils/OauthUtil.kt
@@ -1,0 +1,22 @@
+package com.minmin.authHandsOnClient.utils
+
+import java.security.MessageDigest
+import java.security.SecureRandom
+
+object OauthUtil {
+    fun generateCodeVerifier(): String {
+        val secureRandom = SecureRandom()
+        val octets = ByteArray(32)
+        secureRandom.nextBytes(octets)
+        return Base64UrlUtil.encode(octets)
+    }
+
+    fun generateCodeChallenge(codeVerifier: String): String {
+        val md = MessageDigest.getInstance("SHA-256")
+
+        md.update(codeVerifier.toByteArray(Charsets.ISO_8859_1))
+
+        val digestBytes = md.digest()
+        return Base64UrlUtil.encode(digestBytes)
+    }
+}

--- a/auth-hands-on/auth-hands-on-client/src/main/resources/application.yaml
+++ b/auth-hands-on/auth-hands-on-client/src/main/resources/application.yaml
@@ -3,3 +3,18 @@ spring:
     name: auth-hans-on-client
 server:
   port: 2222
+clientapp:
+  config:
+    apiserver-url: "http://localhost:8888"
+    authorization-endpoint: "http://localhost:8080/realms/auth-hands-on/protocol/openid-connect/auth"
+    token-endpoint: "http://keycloak:8080/realms/auth-hands-on/protocol/openid-connect/token"
+    revoke-endpoint: "http://localhost:8080/realms/auth-hands-on/protocol/openid-connect/revoke"
+    client-id: "${FRONTEND_CLIENT_ID:your-client-id}"
+    client-secret: "${FRONTEND_CLIENT_SECRET:your-client-secret}"
+    scope: "your-scope"
+oauth:
+  config:
+    state: true
+    nonce: true
+    pkce: true
+    formPost: false


### PR DESCRIPTION
## Description

- Added `README.md` in `.devcontainer` with setup details.
- Created `ClientAppConfiguration` and `OauthConfiguration` classes for configuration management.
- Refactored `TokenIntrospectionController` to use `TokenIntrospectionService`.
- Created `TokenIntrospectionService` for handling authorization and token processing.
- Updated `IdToken` class to include `nonce`.
- Converted `Base64UrlUtil` and `JsonUtil` to singleton objects.
- Added `OauthUtil` for PKCE code verifier and challenge generation.
- Updated `application.yaml` with new client app and OAuth configurations.

## Changes

- A       .devcontainer/README.md
- A       auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/configs/ClientAppConfiguration.kt
- A       auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/configs/OauthConfiguration.kt
- M       auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/controllers/TokenIntrospectionController.kt
- M       auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/dtos/IdToken.kt
- A       auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/services/TokenIntrospectionService.kt
- M       auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/utils/Base64UrlUtil.kt
- M       auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/utils/JsonUtil.kt
- A       auth-hands-on/auth-hands-on-client/src/main/kotlin/com/minmin/authHandsOnClient/utils/OauthUtil.kt
- M       auth-hands-on/auth-hands-on-client/src/main/resources/application.yaml

## Reference

- [Kotlinの関数letの使い方を現役エンジニアが解説](https://magazine.techacademy.jp/magazine/19796)
- [KotlinのtakeIf、takeUnlessを使う](https://qiita.com/chohas/items/84de120d1ec1d80e7798)
- [Springでセッションにデータを保存する方法](https://www.tsuzukanai.com/spring-boots-save-session/)
- [OpenID Connectのstateとnonceの違いがわからなかった](https://qiita.com/m28/items/10c3a1de1bdcfda874b1)
- [UriComponentsBuilderとUriComponents、どちらのencodeメソッドを使えばいいのか？](https://iikanji.hatenablog.jp/entry/2021/01/31/172744)
